### PR TITLE
Upgrade protobuf

### DIFF
--- a/crypto-message/Cargo.toml
+++ b/crypto-message/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["cryptocurrency", "blockchain", "trading"]
 ahash = "0.8.11"
 crypto-market-type = "1.1.6"
 crypto-msg-type = "1.0.12"
-protobuf = "3.4.0"
+protobuf = "3.5.0"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
 strum = "0.26.2"

--- a/crypto-message/src/proto/message.rs
+++ b/crypto-message/src/proto/message.rs
@@ -23,7 +23,7 @@
 
 /// Generated files are compatible only with the same version
 /// of protobuf runtime.
-const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_3_4_0;
+const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_3_5_0;
 
 ///  Tick-by-tick trade message.
 #[derive(PartialEq,Clone,Default,Debug)]


### PR DESCRIPTION
Fixes the following build error that I was getting:

```
cannot find value `VERSION_3_4_0` in crate `protobuf`
```